### PR TITLE
Added message attribute to `SuperstaQException`

### DIFF
--- a/applications_superstaq/__init__.py
+++ b/applications_superstaq/__init__.py
@@ -1,7 +1,6 @@
 from applications_superstaq._init_vars import API_URL, API_VERSION
 from applications_superstaq.superstaq_exceptions import (
     SuperstaQException,
-    SuperstaQRequestException,
     SuperstaQModuleNotFoundException,
     SuperstaQNotFoundException,
     SuperstaQUnsuccessfulJobException,
@@ -18,7 +17,6 @@ __all__ = [
     "API_URL",
     "API_VERSION",
     "SuperstaQException",
-    "SuperstaQRequestException",
     "SuperstaQModuleNotFoundException",
     "SuperstaQNotFoundException",
     "SuperstaQUnsuccessfulJobException",

--- a/applications_superstaq/__init__.py
+++ b/applications_superstaq/__init__.py
@@ -1,6 +1,7 @@
 from applications_superstaq._init_vars import API_URL, API_VERSION
 from applications_superstaq.superstaq_exceptions import (
     SuperstaQException,
+    SuperstaQRequestException,
     SuperstaQModuleNotFoundException,
     SuperstaQNotFoundException,
     SuperstaQUnsuccessfulJobException,
@@ -17,6 +18,7 @@ __all__ = [
     "API_URL",
     "API_VERSION",
     "SuperstaQException",
+    "SuperstaQRequestException",
     "SuperstaQModuleNotFoundException",
     "SuperstaQNotFoundException",
     "SuperstaQUnsuccessfulJobException",

--- a/applications_superstaq/superstaq_client.py
+++ b/applications_superstaq/superstaq_client.py
@@ -280,9 +280,12 @@ class _SuperstaQClient:
         if response.status_code not in self.RETRIABLE_STATUS_CODES:
             message = response.reason
             if response.status_code == 400:
-                message = str(response.text)
+                if "message" in response.json():
+                    message = response.json()["message"]
+                else:
+                    message = str(response.text)
             raise applications_superstaq.SuperstaQException(
-                f"Non-retriable error making request to SuperstaQ API, {message}.",
+                f"Non-retriable error making request to SuperstaQ API, {message}",
                 response.status_code,
             )
 

--- a/applications_superstaq/superstaq_client.py
+++ b/applications_superstaq/superstaq_client.py
@@ -279,14 +279,21 @@ class _SuperstaQClient:
 
         if response.status_code not in self.RETRIABLE_STATUS_CODES:
             message = response.reason
+                
             if response.status_code == 400:
+                print("=------------------================")
+                print(response.json())
+                print(type(response))
+                print(response.text)
                 message = str(response.text)
-            raise applications_superstaq.SuperstaQException(
+                if response.json()["type"] == "UserException":
+                    message = str(response.json()["message"])
+            raise applications_superstaq.SuperstaQRequestException(
                 "Non-retriable error making request to SuperstaQ API. "
-                f"Status: {response.status_code} "
-                f"Error : {message}",
+                f"{message}",
                 response.status_code,
             )
+
 
     def _make_request(self, request: Callable[[], requests.Response]) -> requests.Response:
         """Make a request to the API, retrying if necessary.

--- a/applications_superstaq/superstaq_client.py
+++ b/applications_superstaq/superstaq_client.py
@@ -279,21 +279,12 @@ class _SuperstaQClient:
 
         if response.status_code not in self.RETRIABLE_STATUS_CODES:
             message = response.reason
-                
             if response.status_code == 400:
-                print("=------------------================")
-                print(response.json())
-                print(type(response))
-                print(response.text)
                 message = str(response.text)
-                if response.json()["type"] == "UserException":
-                    message = str(response.json()["message"])
-            raise applications_superstaq.SuperstaQRequestException(
-                "Non-retriable error making request to SuperstaQ API. "
-                f"{message}",
+            raise applications_superstaq.SuperstaQException(
+                f"Non-retriable error making request to SuperstaQ API, {message}.",
                 response.status_code,
             )
-
 
     def _make_request(self, request: Callable[[], requests.Response]) -> requests.Response:
         """Make a request to the API, retrying if necessary.

--- a/applications_superstaq/superstaq_client_test.py
+++ b/applications_superstaq/superstaq_client_test.py
@@ -301,6 +301,26 @@ def test_superstaq_client_create_job_timeout(mock_post: mock.MagicMock) -> None:
         _ = client.create_job({"Hello": "World"})
 
 
+@mock.patch("requests.post")
+def test_superstaq_client_create_job_json(mock_post: mock.MagicMock) -> None:
+    mock_post.return_value.ok = False
+    mock_post.return_value.status_code = requests.codes.bad_request
+    mock_post.return_value.json.return_value = {"message": "foo bar"}
+
+    client = applications_superstaq.superstaq_client._SuperstaQClient(
+        client_name="applications-superstaq",
+        remote_host="http://example.com",
+        api_key="to_my_heart",
+    )
+    with pytest.raises(applications_superstaq.SuperstaQException, match="Status code: 400"):
+        _ = client.create_job(
+            serialized_circuits={"Hello": "World"},
+            repetitions=200,
+            target="qpu",
+            ibmq_pulse=True,
+        )
+
+
 @mock.patch("requests.get")
 def test_superstaq_client_get_job(mock_get: mock.MagicMock) -> None:
     mock_get.return_value.ok = True

--- a/applications_superstaq/superstaq_client_test.py
+++ b/applications_superstaq/superstaq_client_test.py
@@ -244,7 +244,7 @@ def test_superstaq_client_create_job_not_retriable(mock_post: mock.MagicMock) ->
         api_key="to_my_heart",
         default_target="simulator",
     )
-    with pytest.raises(applications_superstaq.SuperstaQException, match="Status: 501"):
+    with pytest.raises(applications_superstaq.SuperstaQException, match="Status code: 501"):
         _ = client.create_job({"Hello": "World"})
 
 
@@ -440,7 +440,7 @@ def test_superstaq_client_get_job_not_retriable(mock_get: mock.MagicMock) -> Non
         api_key="to_my_heart",
         default_target="simulator",
     )
-    with pytest.raises(applications_superstaq.SuperstaQException, match="Status: 400"):
+    with pytest.raises(applications_superstaq.SuperstaQException, match="Status code: 400"):
         _ = client.get_job("job_id")
 
 

--- a/applications_superstaq/superstaq_exceptions.py
+++ b/applications_superstaq/superstaq_exceptions.py
@@ -13,6 +13,7 @@ class SuperstaQException(Exception):
     def __init__(self, message: str, status_code: int = None):
         super().__init__(f"Status code: {status_code}, Message: '{message}'")
         self.status_code = status_code
+        self.message = message
 
 
 class SuperstaQModuleNotFoundException(SuperstaQException):

--- a/applications_superstaq/superstaq_exceptions.py
+++ b/applications_superstaq/superstaq_exceptions.py
@@ -11,18 +11,6 @@ class SuperstaQException(Exception):
     """
 
     def __init__(self, message: str, status_code: int = None):
-        super().__init__(f"{message}")
-        self.message = message
-
-
-class SuperstaQRequestException(Exception):
-    """An exception for errors coming from SuperstaQ's API.
-
-    Attributes:
-        status_code: A http status code, if coming from an http response with a failing status.
-    """
-
-    def __init__(self, message: str, status_code: int = None):
         super().__init__(f"Status code: {status_code}, Message: '{message}'")
         self.status_code = status_code
         self.message = message

--- a/applications_superstaq/superstaq_exceptions.py
+++ b/applications_superstaq/superstaq_exceptions.py
@@ -11,6 +11,18 @@ class SuperstaQException(Exception):
     """
 
     def __init__(self, message: str, status_code: int = None):
+        super().__init__(f"{message}")
+        self.message = message
+
+
+class SuperstaQRequestException(Exception):
+    """An exception for errors coming from SuperstaQ's API.
+
+    Attributes:
+        status_code: A http status code, if coming from an http response with a failing status.
+    """
+
+    def __init__(self, message: str, status_code: int = None):
         super().__init__(f"Status code: {status_code}, Message: '{message}'")
         self.status_code = status_code
         self.message = message

--- a/applications_superstaq/superstaq_exceptions_test.py
+++ b/applications_superstaq/superstaq_exceptions_test.py
@@ -18,20 +18,24 @@ def test_superstaq_exception() -> None:
     ex = applications_superstaq.SuperstaQException(message="Hello", status_code=500)
     assert str(ex) == "Status code: 500, Message: 'Hello'"
     assert ex.status_code == 500
+    assert ex.message == "Hello"
 
 
 def test_module_not_found_exception() -> None:
     ex = applications_superstaq.SuperstaQModuleNotFoundException("hello_world", "test")
     assert str(ex) == "Status code: None, Message: ''test' requires module 'hello_world''"
+    assert ex.message == "'test' requires module 'hello_world'"
 
 
 def test_superstaq_not_found_exception() -> None:
     ex = applications_superstaq.SuperstaQNotFoundException(message="Where are you")
     assert str(ex) == "Status code: 404, Message: 'Where are you'"
     assert ex.status_code == 404
+    assert ex.message == "Where are you"
 
 
 def test_superstaq_unsuccessful_job_exception() -> None:
     ex = applications_superstaq.SuperstaQUnsuccessfulJobException(job_id="SWE", status="canceled")
     assert str(ex) == "Status code: None, Message: 'Job SWE was canceled.'"
     assert ex.status_code is None
+    assert ex.message == "Job SWE was canceled."


### PR DESCRIPTION
This is so we can access the exception message independently of the status code (e.g., useful for displaying top-layer error messages with minimal clutter).