### PR TITLE
add `[dev]` option to `app-ss` package, which installs `dev-requirements.txt`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
+          pip install .[dev]
       - name: Format
         run: |
           check/format_.py
@@ -40,8 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
+          pip install .[dev]
       - name: Pylint
         run: |
           check/pylint_.py
@@ -58,8 +56,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
+          pip install .[dev]
       - name: Flake8
         run: |
           check/flake8_.py
@@ -76,8 +73,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
+          pip install .[dev]
       - name: Type check
         run: |
           check/mypy_.py
@@ -94,8 +90,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
+          pip install .[dev]
       - name: Pytest check
         run: |
           check/pytest_.py
@@ -112,8 +107,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
+          pip install .[dev]
       - name: Pytest-mac check
         run: |
           check/pytest_.py
@@ -130,8 +124,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          if (Test-Path "dev-requirements.txt") {pip install -r dev-requirements.txt}
+          pip install .[dev]
       - name: Pytest-win check
         run: |
           check/pytest_.py
@@ -149,8 +142,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
+          pip install .[dev]
       - name: Coverage check
         run: |
           check/coverage_.py

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 black[jupyter]~=22.3.0
 flake8-import-order~=0.18.1
 flake8~=3.8.4
-mypy~=0.961
+mypy>=0.961
 nbmake~=1.3.0
 pylint>=2.13.0
 pytest-cov~=2.11.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,9 @@
 black[jupyter]~=22.3.0
 flake8-import-order~=0.18.1
 flake8~=3.8.4
-mypy==0.961
+mypy~=0.961
 nbmake~=1.3.0
 pylint>=2.13.0
-pytest-cov==2.11.1
+pytest-cov~=2.11.1
 pytest-socket~=0.4.1
 pytest~=6.1.2

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,10 @@ long_description = io.open("README.md", encoding="utf-8").read()
 requirements = open("requirements.txt").readlines()
 requirements = [r.strip() for r in requirements]
 
+# Read in dev requirements, installed with 'pip install applications-superstaq[dev]'
+dev_requirements = open("dev-requirements.txt").readlines()
+dev_requirements = [r.strip() for r in dev_requirements]
+
 # Sanity check
 assert __version__, "Version string cannot be empty"
 
@@ -33,6 +37,7 @@ setup(
     author_email="pranav@super.tech",
     python_requires=(">=3.6.0"),
     install_requires=requirements,
+    extras_require={"dev": dev_requirements},
     license="Apache 2",
     description=description,
     long_description=long_description,


### PR DESCRIPTION
fixes #71 

This PR will be followed up with:
- downstream repos removing explicit `check` requirements, and instead adding `applications-superstaq[dev]` to their `dev-requirements.txt`
- downstream repos also adding a `[dev]` option?