### PR TITLE
Minor check fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,8 @@ jobs:
         run: |
           check/mypy_.py
 
-  pytest:
-    name: Pytest Ubuntu
+  coverage:
+    name: Pytest and Coverage check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -91,9 +91,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[dev]
-      - name: Pytest check
+      - name: Coverage check
         run: |
-          check/pytest_.py
+          check/coverage_.py
 
   pytest-mac:
     name: Pytest macOS
@@ -129,20 +129,3 @@ jobs:
         run: |
           check/pytest_.py
         shell: bash
-
-  coverage:
-    name: Coverage check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .[dev]
-      - name: Coverage check
-        run: |
-          check/coverage_.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           pip install .[dev]
       - name: Pylint
         run: |
-          check/pylint_.py
+          check/pylint_.py --all
 
   flake8:
     name: Flake8 check

--- a/applications_superstaq/check/all_.py
+++ b/applications_superstaq/check/all_.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 
-import argparse
 import sys
 import textwrap
-from typing import Optional
 
 from applications_superstaq.check import (
     build_docs,
@@ -17,13 +15,9 @@ from applications_superstaq.check import (
 )
 
 
-def run(
-    *args: str,
-    parser: Optional[argparse.ArgumentParser] = None,
-) -> int:
-    if not parser:
-        parser = check_utils.get_file_parser()
+def run(*args: str) -> int:
 
+    parser = check_utils.get_file_parser()
     parser.description = textwrap.dedent(
         """
         Runs all checks on the repository.
@@ -45,36 +39,26 @@ def run(
         dest="force_all",
         help="'Hard force' ~ continue past (i.e. do not exit after) all failing checks.",
     )
-    parser.add_argument(
-        "-i",
-        "--incremental",
-        dest="revisions",
-        nargs="*",
-        action="extend",
-        help="Run checks in incremental mode.",
-    )
-    parsed_args = parser.parse_intermixed_args(args)
-    files = parsed_args.files
-    revisions = parsed_args.revisions
 
-    default_mode = not files and revisions is None
+    parsed_args = parser.parse_intermixed_args(args)
+    args_to_pass = parsed_args.files
+    if parsed_args.revisions is not None:
+        args_to_pass += ["-i", *parsed_args.revisions]
+
+    default_mode = not parsed_args.files and parsed_args.revisions is None
     checks_failed = 0
 
     # run formatting checks
     exit_on_failure = not (parsed_args.force_formats or parsed_args.force_all)
-    checks_failed |= format_.run(*files, revisions=revisions, exit_on_failure=exit_on_failure)
-    checks_failed |= flake8_.run(*files, revisions=revisions, exit_on_failure=exit_on_failure)
-    checks_failed |= pylint_.run(*files, revisions=revisions, exit_on_failure=exit_on_failure)
+    checks_failed |= format_.run(*args_to_pass, exit_on_failure=exit_on_failure)
+    checks_failed |= flake8_.run(*args_to_pass, exit_on_failure=exit_on_failure, silent=True)
+    checks_failed |= pylint_.run(*args_to_pass, exit_on_failure=exit_on_failure, silent=True)
 
     # run typing and coverage checks
     exit_on_failure = not parsed_args.force_all
-    # typing changes are likely to have side effects, so always run mypy on the entire repo
-    checks_failed |= mypy_.run(revisions=revisions, exit_on_failure=exit_on_failure)
+    checks_failed |= mypy_.run(*args_to_pass, exit_on_failure=exit_on_failure, silent=True)
     checks_failed |= coverage_.run(
-        *files,
-        revisions=revisions,
-        exit_on_failure=exit_on_failure,
-        suppress_warnings=default_mode,
+        *args_to_pass, exit_on_failure=exit_on_failure, silent=default_mode
     )
 
     # check that all pip requirements files are in order

--- a/applications_superstaq/check/all_.py
+++ b/applications_superstaq/check/all_.py
@@ -64,12 +64,7 @@ def run(
     exit_on_failure = not (parsed_args.force_formats or parsed_args.force_all)
     checks_failed |= format_.run(*files, revisions=revisions, exit_on_failure=exit_on_failure)
     checks_failed |= flake8_.run(*files, revisions=revisions, exit_on_failure=exit_on_failure)
-    # pylint is slow, so always run pylint in incremental mode
-    checks_failed |= pylint_.run(
-        *files,
-        revisions=[] if default_mode else revisions,
-        exit_on_failure=exit_on_failure,
-    )
+    checks_failed |= pylint_.run(*files, revisions=revisions, exit_on_failure=exit_on_failure)
 
     # run typing and coverage checks
     exit_on_failure = not parsed_args.force_all

--- a/applications_superstaq/check/all_.py
+++ b/applications_superstaq/check/all_.py
@@ -47,7 +47,7 @@ def run(*args: str, parser: argparse.ArgumentParser = check_utils.get_file_parse
         action="extend",
         help="Run checks in incremental mode.",
     )
-    parsed_args = parser.parse_args(args)
+    parsed_args = parser.parse_intermixed_args(args)
     files = parsed_args.files
     revisions = parsed_args.revisions
 

--- a/applications_superstaq/check/all_.py
+++ b/applications_superstaq/check/all_.py
@@ -3,6 +3,7 @@
 import argparse
 import sys
 import textwrap
+from typing import Optional
 
 from applications_superstaq.check import (
     build_docs,
@@ -16,7 +17,12 @@ from applications_superstaq.check import (
 )
 
 
-def run(*args: str, parser: argparse.ArgumentParser = check_utils.get_file_parser()) -> int:
+def run(
+    *args: str,
+    parser: Optional[argparse.ArgumentParser] = None,
+) -> int:
+    if not parser:
+        parser = check_utils.get_file_parser()
 
     parser.description = textwrap.dedent(
         """

--- a/applications_superstaq/check/all_.py
+++ b/applications_superstaq/check/all_.py
@@ -49,6 +49,8 @@ def run(*args: str) -> int:
     checks_failed = 0
 
     # run formatting checks
+    # silence all but the first check to avoid printing duplicate info about incrmental files
+    # silencing does not affect warnings and errors
     exit_on_failure = not (parsed_args.force_formats or parsed_args.force_all)
     checks_failed |= format_.run(*args_to_pass, exit_on_failure=exit_on_failure)
     checks_failed |= flake8_.run(*args_to_pass, exit_on_failure=exit_on_failure, silent=True)

--- a/applications_superstaq/check/build_docs.py
+++ b/applications_superstaq/check/build_docs.py
@@ -18,7 +18,7 @@ def run(*args: str) -> int:
         Checks that the docs build successfully.
         """
     )
-    parser.parse_known_args(args)
+    parser.parse_args(args)  # "dummy" parsing to print help text
 
     docs_dir = os.path.join(check_utils.root_dir, "docs")
     if os.path.isdir(docs_dir):

--- a/applications_superstaq/check/build_docs.py
+++ b/applications_superstaq/check/build_docs.py
@@ -10,10 +10,9 @@ from applications_superstaq.check import check_utils
 
 
 @check_utils.enable_exit_on_failure
-def run(
-    *args: str, parser: argparse.ArgumentParser = check_utils.get_file_parser(add_files=False)
-) -> int:
+def run(*args: str) -> int:
 
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.description = textwrap.dedent(
         """
         Checks that the docs build successfully.

--- a/applications_superstaq/check/build_docs.py
+++ b/applications_superstaq/check/build_docs.py
@@ -18,7 +18,7 @@ def run(*args: str) -> int:
         Checks that the docs build successfully.
         """
     )
-    parser.parse_args(args)
+    parser.parse_known_args(args)
 
     docs_dir = os.path.join(check_utils.root_dir, "docs")
     if os.path.isdir(docs_dir):

--- a/applications_superstaq/check/build_docs.py
+++ b/applications_superstaq/check/build_docs.py
@@ -18,7 +18,7 @@ def run(*args: str) -> int:
         Checks that the docs build successfully.
         """
     )
-    parser.parse_args(args)  # "dummy" parsing to print help text
+    parser.parse_args(args)  # placeholder parsing to enable printing help text
 
     docs_dir = os.path.join(check_utils.root_dir, "docs")
     if os.path.isdir(docs_dir):

--- a/applications_superstaq/check/check_utils.py
+++ b/applications_superstaq/check/check_utils.py
@@ -148,6 +148,7 @@ def _get_ancestor(*revisions: str, silent: bool = False) -> str:
     print()
     print()
     print("revisions:", revisions)
+    print("cwd:", os.getcwd())
     print()
     print()
     print()

--- a/applications_superstaq/check/check_utils.py
+++ b/applications_superstaq/check/check_utils.py
@@ -221,7 +221,7 @@ def get_file_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def get_file_args(
+def extract_files(
     parsed_args: argparse.Namespace,
     include: Union[str, Iterable[str]],
     exclude: Union[str, Iterable[str]] = "",

--- a/applications_superstaq/check/check_utils.py
+++ b/applications_superstaq/check/check_utils.py
@@ -93,7 +93,7 @@ def inclusion_filter(exclude: Union[str, Iterable[str]]) -> Callable[[str], bool
 
 def get_changed_files(
     include: Union[str, Iterable[str]],
-    exclude: Union[str, Iterable[str]] = "",
+    exclude: Union[str, Iterable[str]],
     revisions: Optional[Iterable[str]] = None,
     silent: bool = False,
 ) -> List[str]:
@@ -101,13 +101,18 @@ def get_changed_files(
     Get the files of interest that have been changed in the current branch.
     Here "files of interest" means all files identified by get_tracked_files (see above).
 
-    You can optionally specify a git revisions to compare against when determining whether a file is
-    considered to have "changed".  If multiple revisions are provided, this script compares against
-    their most recent common ancestor.  If no revisions are specified, this script will default to
-    the first of the default_branches (specified above) that it finds.  If none of these branches
-    exists, this method raises a ValueError.
+    You can specify git revisions to compare against when determining whether a file is considered
+    to have "changed".  If multiple revisions are provided, this script compares against their most
+    recent common ancestor.
+
+    If an empty list of revisions is specified, this script will default to the first of the
+    default_branches (specified above) that it finds.  If none of these branches exists, this method
+    raises a ValueError.
     """
-    revisions = list(revisions) if revisions else []
+    if revisions is None:
+        return []
+    else:
+        revisions = list(revisions)
 
     # verify that all arguments are valid revisions
     invalid_revisions = [revision for revision in revisions if not _revision_exists(revision)]
@@ -223,7 +228,7 @@ def get_file_args(
     silent: bool = False,
 ) -> List[str]:
     files = parsed_args.files if "files" in parsed_args else []
-    if "revisions" in parsed_args and parsed_args.revisions is not None:
+    if "revisions" in parsed_args:
         files += get_changed_files(include, exclude, parsed_args.revisions, silent=silent)
     return files if files else get_tracked_files(include, exclude)
 

--- a/applications_superstaq/check/check_utils.py
+++ b/applications_superstaq/check/check_utils.py
@@ -143,17 +143,6 @@ def _get_ancestor(*revisions: str, silent: bool = False) -> str:
     """
     Helper function to identify the most recent common ancestor of the given git revisions.
     """
-    print()
-    print()
-    print()
-    print()
-    print("revisions:", revisions)
-    print("cwd:", os.getcwd())
-    print("root_dir:", root_dir)
-    print()
-    print()
-    print()
-    print()
     if len(revisions) == 1:
         return revisions[0]
 
@@ -167,7 +156,6 @@ def _get_ancestor(*revisions: str, silent: bool = False) -> str:
         for branch in default_branches:
             if _revision_exists(branch):
                 return branch
-
         error = f"Default git revisions not found: {default_branches}"
         raise RuntimeError(failure(error))
 

--- a/applications_superstaq/check/check_utils.py
+++ b/applications_superstaq/check/check_utils.py
@@ -143,6 +143,15 @@ def _get_ancestor(*revisions: str, silent: bool = False) -> str:
     """
     Helper function to identify the most recent common ancestor of the given git revisions.
     """
+    print()
+    print()
+    print()
+    print()
+    print("revisions:", revisions)
+    print()
+    print()
+    print()
+    print()
     if len(revisions) == 1:
         return revisions[0]
 
@@ -157,7 +166,7 @@ def _get_ancestor(*revisions: str, silent: bool = False) -> str:
             if _revision_exists(branch):
                 return branch
 
-        error = f"No default git revision found to compare against {default_branches}"
+        error = f"Default git revisions not found: {default_branches}"
         raise RuntimeError(failure(error))
 
 

--- a/applications_superstaq/check/check_utils.py
+++ b/applications_superstaq/check/check_utils.py
@@ -197,10 +197,8 @@ def get_test_files(*files: str, exclude: Union[str, Iterable[str]] = "", silent:
 # file parsing, incremental checks, and decorator to exit instead of returning a failing exit code
 
 
-def get_file_parser(add_help: bool = True) -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        add_help=add_help, formatter_class=argparse.RawDescriptionHelpFormatter
-    )
+def get_file_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter)
 
     help_text = "The files to check. If not passed any files, inspects the entire repo."
     parser.add_argument("files", nargs="*", help=help_text)

--- a/applications_superstaq/check/check_utils.py
+++ b/applications_superstaq/check/check_utils.py
@@ -149,6 +149,7 @@ def _get_ancestor(*revisions: str, silent: bool = False) -> str:
     print()
     print("revisions:", revisions)
     print("cwd:", os.getcwd())
+    print("root_dir:", root_dir)
     print()
     print()
     print()

--- a/applications_superstaq/check/check_utils.py
+++ b/applications_superstaq/check/check_utils.py
@@ -285,21 +285,3 @@ def enable_exit_on_failure(func: Callable[..., int]) -> Callable[..., int]:
         return returncode
 
     return func_with_exit
-
-
-def extract_file_args(func: Callable[..., int]) -> Callable[..., int]:
-    """Decorator to extract files from the arguments to a function."""
-
-    def func_with_files(*args: str, files: Optional[Iterable[str]] = None, **kwargs: Any) -> int:
-        file_args = []
-        for idx, arg in enumerate(args):
-            if arg[0] != "-":
-                file_args.append(arg)
-            else:
-                args = args[idx:]
-                break
-        if file_args:
-            files = list(files) + file_args if files else file_args
-        return func(*args, files=files, **kwargs)
-
-    return func_with_files

--- a/applications_superstaq/check/check_utils.py
+++ b/applications_superstaq/check/check_utils.py
@@ -276,13 +276,13 @@ def enable_incremental(
     return incremental_decorator
 
 
-def enable_exit_on_failure(func: Callable[..., int]) -> Callable[..., int]:
+def enable_exit_on_failure(func_with_returncode: Callable[..., int]) -> Callable[..., int]:
     """
     Decorator optionally allowing a function to exit instead of returning a failing return code.
     """
 
     def func_with_exit(*args: Any, exit_on_failure: bool = False, **kwargs: Any) -> int:
-        returncode = func(*args, **kwargs)
+        returncode = func_with_returncode(*args, **kwargs)
         if exit_on_failure and returncode:
             exit(returncode)
         return returncode

--- a/applications_superstaq/check/check_utils.py
+++ b/applications_superstaq/check/check_utils.py
@@ -200,13 +200,12 @@ def get_test_files(
 # decorators to add features to checks
 
 
-def get_file_parser(add_files: bool = True, add_help: bool = True) -> argparse.ArgumentParser:
+def get_file_parser(add_help: bool = True) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         add_help=add_help, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    if add_files:
-        files_help_text = "The files to check. If not passed any files, inspects the entire repo."
-        parser.add_argument("files", nargs="*", help=files_help_text)
+    files_help_text = "The files to check. If not passed any files, inspects the entire repo."
+    parser.add_argument("files", nargs="*", help=files_help_text)
     return parser
 
 

--- a/applications_superstaq/check/check_utils.py
+++ b/applications_superstaq/check/check_utils.py
@@ -292,17 +292,16 @@ def enable_exit_on_failure(func: Callable[..., int]) -> Callable[..., int]:
 def extract_file_args(func: Callable[..., int]) -> Callable[..., int]:
     """Decorator to extract files from the arguments to a function."""
 
-    def func_with_files(*args: Any, files: Optional[Iterable[str]] = None, **kwargs: Any) -> int:
+    def func_with_files(*args: str, files: Optional[Iterable[str]] = None, **kwargs: Any) -> int:
         file_args = []
-        othr_args = []
-        for arg in args:
-            if os.path.isfile(arg):
-                file_args.append(os.path.relpath(arg, root_dir))
+        for idx, arg in enumerate(args):
+            if arg[0] != "-":
+                file_args.append(arg)
             else:
-                othr_args.append(arg)
-
+                args = args[idx:]
+                break
         if file_args:
             files = list(files) + file_args if files else file_args
-        return func(*othr_args, files=files, **kwargs)
+        return func(*args, files=files, **kwargs)
 
     return func_with_files

--- a/applications_superstaq/check/check_utils.py
+++ b/applications_superstaq/check/check_utils.py
@@ -223,7 +223,10 @@ def enable_incremental(
     """
 
     def incremental_decorator(func: Callable[..., int]) -> Callable[..., int]:
-        """Inner decorator that uses match_patterns."""
+        """
+        Inner decorator that uses the match_patterns and exclude arguments that were passed to the
+        outer decorator.
+        """
 
         def incremental_func(
             *args: Any,

--- a/applications_superstaq/check/check_utils.py
+++ b/applications_superstaq/check/check_utils.py
@@ -92,7 +92,7 @@ def inclusion_filter(exclude: Optional[Union[str, Iterable[str]]]) -> Callable[[
 
 def get_changed_files(
     match_patterns: Iterable[str],
-    revisions: Iterable[str],
+    revisions: Iterable[str] = (),
     silent: bool = False,
     exclude: Optional[Union[str, Iterable[str]]] = None,
 ) -> List[str]:

--- a/applications_superstaq/check/coverage_.py
+++ b/applications_superstaq/check/coverage_.py
@@ -26,7 +26,7 @@ def run(
     )
 
     parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
-    files = check_utils.get_file_args(parsed_args, include, exclude, silent)
+    files = check_utils.extract_files(parsed_args, include, exclude, silent)
 
     silent = silent or not (parsed_args.files or parsed_args.revisions)
     test_files = check_utils.get_test_files(*files, exclude=exclude, silent=silent)

--- a/applications_superstaq/check/coverage_.py
+++ b/applications_superstaq/check/coverage_.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 
 import argparse
-import os
-import re
 import subprocess
 import sys
 import textwrap
-from typing import Iterable, List, Optional, Union
+from typing import Iterable, Optional, Union
 
 from applications_superstaq.check import check_utils
 
@@ -38,7 +36,7 @@ def run(
         files = check_utils.get_tracked_files(*default_files_to_check, exclude=exclude)
         suppress_warnings = True
 
-    test_files = _get_test_files(*files, exclude=exclude, suppress_warnings=suppress_warnings)
+    test_files = check_utils.get_test_files(*files, exclude=exclude, silent=suppress_warnings)
 
     if test_files:
         include_files = "--include=" + ",".join(files)
@@ -65,31 +63,6 @@ def run(
         print("No test files to check for pytest and coverage.")
 
     return 0
-
-
-def _get_test_files(
-    *files: str, exclude: Optional[Union[str, Iterable[str]]] = None, suppress_warnings: bool
-) -> List[str]:
-    """
-    For the given files, identify all associated test files (i.e. files with the same name, but
-    with a "_test.py" suffix).
-    """
-    should_include = check_utils.inclusion_filter(exclude)
-
-    test_files = set()
-    for file in files:
-        if file.endswith("_test.py"):
-            test_files.add(file)
-
-        else:
-            test_file = re.sub(r"\.py$", "_test.py", file)
-            test_file_exists = os.path.isfile(os.path.join(check_utils.root_dir, test_file))
-            if test_file_exists and should_include(test_file):
-                test_files.add(test_file)
-            elif not suppress_warnings:
-                print(check_utils.warning(f"WARNING: no test file found for {file}"))
-
-    return list(test_files)
 
 
 if __name__ == "__main__":

--- a/applications_superstaq/check/coverage_.py
+++ b/applications_superstaq/check/coverage_.py
@@ -18,8 +18,10 @@ def run(
     *args: str,
     exclude: Optional[Union[str, Iterable[str]]] = default_exclude,
     suppress_warnings: bool = False,
-    parser: argparse.ArgumentParser = check_utils.get_file_parser(),
+    parser: Optional[argparse.ArgumentParser] = None,
 ) -> int:
+    if not parser:
+        parser = check_utils.get_file_parser()
 
     parser.description = textwrap.dedent(
         """

--- a/applications_superstaq/check/coverage_.py
+++ b/applications_superstaq/check/coverage_.py
@@ -22,14 +22,20 @@ def run(
         Checks to make sure that all code is covered by unit tests.
         Fails if any pytest fails or if coverage is not 100%.
         Ignores integration tests and files in the [repo_root]/examples directory.
+        Passes --disable-socket to coverage, unless running with --enable-socket.
         """
     )
+
+    parser.add_argument("--enable-socket", action="store_true", help="Force-enable socket.")
 
     parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
     files = check_utils.extract_files(parsed_args, include, exclude, silent)
 
     silent = silent or not (parsed_args.files or parsed_args.revisions)
     test_files = check_utils.get_test_files(*files, exclude=exclude, silent=silent)
+
+    if not parsed_args.enable_socket:
+        args_to_pass += ["--disable-socket"]
 
     if test_files:
         include_files = "--include=" + ",".join(files)

--- a/applications_superstaq/check/coverage_.py
+++ b/applications_superstaq/check/coverage_.py
@@ -11,6 +11,7 @@ from applications_superstaq.check import check_utils
 default_files_to_check = ("*.py",)
 default_exclude = ("*_integration_test.py",)
 
+
 @check_utils.enable_exit_on_failure
 @check_utils.extract_file_args
 @check_utils.enable_incremental(*default_files_to_check, exclude=default_exclude)

--- a/applications_superstaq/check/coverage_.py
+++ b/applications_superstaq/check/coverage_.py
@@ -18,9 +18,9 @@ default_exclude = ("*_integration_test.py",)
 def run(
     *args: str,
     files: Optional[Iterable[str]] = None,
-    parser: argparse.ArgumentParser = check_utils.get_file_parser(),
-    suppress_warnings: bool = False,
     exclude: Optional[Union[str, Iterable[str]]] = default_exclude,
+    suppress_warnings: bool = False,
+    parser: argparse.ArgumentParser = check_utils.get_file_parser(),
 ) -> int:
 
     parser.description = textwrap.dedent(

--- a/applications_superstaq/check/coverage_.py
+++ b/applications_superstaq/check/coverage_.py
@@ -9,8 +9,7 @@ from typing import Iterable, Optional, Union
 from applications_superstaq.check import check_utils
 
 default_files_to_check = ("*.py",)
-default_exclude = ("examples/*", "*_integration_test.py")
-
+default_exclude = ("*_integration_test.py",)
 
 @check_utils.enable_exit_on_failure
 @check_utils.extract_file_args

--- a/applications_superstaq/check/flake8_.py
+++ b/applications_superstaq/check/flake8_.py
@@ -4,7 +4,7 @@ import argparse
 import subprocess
 import sys
 import textwrap
-from typing import Iterable, Optional
+from typing import Optional
 
 from applications_superstaq.check import check_utils
 
@@ -15,7 +15,6 @@ default_files_to_check = ("*.py",)
 @check_utils.enable_incremental(*default_files_to_check)
 def run(
     *args: str,
-    files: Optional[Iterable[str]] = None,
     parser: Optional[argparse.ArgumentParser] = None,
 ) -> int:
     if not parser:

--- a/applications_superstaq/check/flake8_.py
+++ b/applications_superstaq/check/flake8_.py
@@ -1,25 +1,22 @@
 #!/usr/bin/env python3
 
-import argparse
 import subprocess
 import sys
 import textwrap
-from typing import Optional
+from typing import Iterable, Union
 
 from applications_superstaq.check import check_utils
 
-default_files_to_check = ("*.py",)
-
 
 @check_utils.enable_exit_on_failure
-@check_utils.enable_incremental(*default_files_to_check)
 def run(
     *args: str,
-    parser: Optional[argparse.ArgumentParser] = None,
+    include: Union[str, Iterable[str]] = "*.py",
+    exclude: Union[str, Iterable[str]] = "*_integration_test.py",
+    silent: bool = False,
 ) -> int:
-    if not parser:
-        parser = check_utils.get_file_parser()
 
+    parser = check_utils.get_file_parser()
     parser.description = textwrap.dedent(
         """
         Runs flake8 on the repository (formatting check).
@@ -27,10 +24,7 @@ def run(
     )
 
     parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
-    files = parsed_args.files
-
-    if not files:
-        files = check_utils.get_tracked_files(*default_files_to_check)
+    files = check_utils.get_file_args(parsed_args, include, exclude, silent)
 
     return subprocess.call(["flake8", *files, *args_to_pass], cwd=check_utils.root_dir)
 

--- a/applications_superstaq/check/flake8_.py
+++ b/applications_superstaq/check/flake8_.py
@@ -24,7 +24,7 @@ def run(
     )
 
     parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
-    files = check_utils.get_file_args(parsed_args, include, exclude, silent)
+    files = check_utils.extract_files(parsed_args, include, exclude, silent)
 
     return subprocess.call(["flake8", *files, *args_to_pass], cwd=check_utils.root_dir)
 

--- a/applications_superstaq/check/flake8_.py
+++ b/applications_superstaq/check/flake8_.py
@@ -16,8 +16,10 @@ default_files_to_check = ("*.py",)
 def run(
     *args: str,
     files: Optional[Iterable[str]] = None,
-    parser: argparse.ArgumentParser = check_utils.get_file_parser(),
+    parser: Optional[argparse.ArgumentParser] = None,
 ) -> int:
+    if not parser:
+        parser = check_utils.get_file_parser()
 
     parser.description = textwrap.dedent(
         """

--- a/applications_superstaq/check/flake8_.py
+++ b/applications_superstaq/check/flake8_.py
@@ -12,7 +12,6 @@ default_files_to_check = ("*.py",)
 
 
 @check_utils.enable_exit_on_failure
-@check_utils.extract_file_args
 @check_utils.enable_incremental(*default_files_to_check)
 def run(
     *args: str,
@@ -25,12 +24,14 @@ def run(
         Runs flake8 on the repository (formatting check).
         """
     )
-    parser.parse_args(args)
 
-    if files is None:
+    parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
+    files = parsed_args.files
+
+    if not files:
         files = check_utils.get_tracked_files(*default_files_to_check)
 
-    return subprocess.call(["flake8", *args, *files], cwd=check_utils.root_dir)
+    return subprocess.call(["flake8", *files, *args_to_pass], cwd=check_utils.root_dir)
 
 
 if __name__ == "__main__":

--- a/applications_superstaq/check/format_.py
+++ b/applications_superstaq/check/format_.py
@@ -5,7 +5,6 @@ import os
 import subprocess
 import sys
 import textwrap
-from typing import Iterable, Optional
 
 from applications_superstaq.check import check_utils
 
@@ -13,11 +12,9 @@ default_files_to_check = ("*.py", "*.ipynb")
 
 
 @check_utils.enable_exit_on_failure
-@check_utils.extract_file_args
 @check_utils.enable_incremental(*default_files_to_check)
 def run(
     *args: str,
-    files: Optional[Iterable[str]] = None,
     parser: argparse.ArgumentParser = check_utils.get_file_parser(),
 ) -> int:
 
@@ -28,16 +25,17 @@ def run(
     )
 
     parser.add_argument("--apply", action="store_true", help="Apply changes to files.")
-    parsed_args, unknown_args = parser.parse_known_intermixed_args(args)
+    parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
+    files = parsed_args.files
 
-    args = ("--color", "--line-length=100") + tuple(unknown_args)
+    args_to_pass = ["--color", "--line-length=100"] + args_to_pass
     if not parsed_args.apply:
-        args = ("--diff", "--check") + args
+        args_to_pass = ["--diff", "--check"] + args_to_pass
 
-    if files is None:
+    if not files:
         files = check_utils.get_tracked_files(*default_files_to_check)
 
-    returncode = subprocess.call(["black", *args, *files], cwd=check_utils.root_dir)
+    returncode = subprocess.call(["black", *files, *args_to_pass], cwd=check_utils.root_dir)
 
     if returncode == 1:
         # some files should be reformatted, but there don't seem to be any bona fide errors

--- a/applications_superstaq/check/format_.py
+++ b/applications_superstaq/check/format_.py
@@ -27,7 +27,7 @@ def run(
     parser.add_argument("--apply", action="store_true", help="Apply changes to files.")
 
     parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
-    files = check_utils.get_file_args(parsed_args, include, exclude, silent)
+    files = check_utils.extract_files(parsed_args, include, exclude, silent)
 
     args_to_pass = ["--color", "--line-length=100"] + args_to_pass
     if not parsed_args.apply:

--- a/applications_superstaq/check/format_.py
+++ b/applications_superstaq/check/format_.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 import textwrap
+from typing import Optional
 
 from applications_superstaq.check import check_utils
 
@@ -15,8 +16,10 @@ default_files_to_check = ("*.py", "*.ipynb")
 @check_utils.enable_incremental(*default_files_to_check)
 def run(
     *args: str,
-    parser: argparse.ArgumentParser = check_utils.get_file_parser(),
+    parser: Optional[argparse.ArgumentParser] = None,
 ) -> int:
+    if not parser:
+        parser = check_utils.get_file_parser()
 
     parser.description = textwrap.dedent(
         """

--- a/applications_superstaq/check/mypy_.py
+++ b/applications_superstaq/check/mypy_.py
@@ -25,7 +25,7 @@ def run(
     )
 
     parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
-    files = check_utils.get_file_args(parsed_args, include, exclude, silent)
+    files = check_utils.extract_files(parsed_args, include, exclude, silent)
 
     return subprocess.call(["mypy", *files, *args_to_pass], cwd=check_utils.root_dir)
 

--- a/applications_superstaq/check/mypy_.py
+++ b/applications_superstaq/check/mypy_.py
@@ -1,25 +1,22 @@
 #!/usr/bin/env python3
 
-import argparse
 import subprocess
 import sys
 import textwrap
-from typing import Optional
+from typing import Iterable, Union
 
 from applications_superstaq.check import check_utils
 
-default_files_to_check = ("*.py",)
-
 
 @check_utils.enable_exit_on_failure
-@check_utils.enable_incremental(*default_files_to_check)
 def run(
     *args: str,
-    parser: Optional[argparse.ArgumentParser] = None,
+    include: Union[str, Iterable[str]] = "*.py",
+    exclude: Union[str, Iterable[str]] = "",
+    silent: bool = False,
 ) -> int:
-    if not parser:
-        parser = check_utils.get_file_parser()
 
+    parser = check_utils.get_file_parser()
     parser.description = textwrap.dedent(
         """
         Runs mypy on the repository (typing check).
@@ -28,10 +25,7 @@ def run(
     )
 
     parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
-    files = parsed_args.files
-
-    if not files:
-        files = check_utils.get_tracked_files(*default_files_to_check)
+    files = check_utils.get_file_args(parsed_args, include, exclude, silent)
 
     return subprocess.call(["mypy", *files, *args_to_pass], cwd=check_utils.root_dir)
 

--- a/applications_superstaq/check/mypy_.py
+++ b/applications_superstaq/check/mypy_.py
@@ -4,6 +4,7 @@ import argparse
 import subprocess
 import sys
 import textwrap
+from typing import Optional
 
 from applications_superstaq.check import check_utils
 
@@ -14,8 +15,10 @@ default_files_to_check = ("*.py",)
 @check_utils.enable_incremental(*default_files_to_check)
 def run(
     *args: str,
-    parser: argparse.ArgumentParser = check_utils.get_file_parser(),
+    parser: Optional[argparse.ArgumentParser] = None,
 ) -> int:
+    if not parser:
+        parser = check_utils.get_file_parser()
 
     parser.description = textwrap.dedent(
         """

--- a/applications_superstaq/check/mypy_.py
+++ b/applications_superstaq/check/mypy_.py
@@ -4,7 +4,6 @@ import argparse
 import subprocess
 import sys
 import textwrap
-from typing import Iterable, Optional
 
 from applications_superstaq.check import check_utils
 
@@ -12,11 +11,9 @@ default_files_to_check = ("*.py",)
 
 
 @check_utils.enable_exit_on_failure
-@check_utils.extract_file_args
 @check_utils.enable_incremental(*default_files_to_check)
 def run(
     *args: str,
-    files: Optional[Iterable[str]] = None,
     parser: argparse.ArgumentParser = check_utils.get_file_parser(),
 ) -> int:
 
@@ -26,12 +23,14 @@ def run(
         Ignores files in the [repo_root]/examples directory.
         """
     )
-    parser.parse_args(args)
 
-    if files is None:
+    parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
+    files = parsed_args.files
+
+    if not files:
         files = check_utils.get_tracked_files(*default_files_to_check)
 
-    return subprocess.call(["mypy", *args, *files], cwd=check_utils.root_dir)
+    return subprocess.call(["mypy", *files, *args_to_pass], cwd=check_utils.root_dir)
 
 
 if __name__ == "__main__":

--- a/applications_superstaq/check/pylint_.py
+++ b/applications_superstaq/check/pylint_.py
@@ -27,7 +27,7 @@ def run(
     parser.add_argument("-a", "--all", action="store_true", help="Run pylint on the entire repo.")
 
     parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
-    files = check_utils.get_file_args(parsed_args, include, exclude, silent)
+    files = check_utils.extract_files(parsed_args, include, exclude, silent)
 
     if parsed_args.all:
         files += check_utils.get_tracked_files(include, exclude)

--- a/applications_superstaq/check/pylint_.py
+++ b/applications_superstaq/check/pylint_.py
@@ -16,8 +16,10 @@ default_files_to_check = ("*.py",)
 def run(
     *args: str,
     files: Optional[Iterable[str]] = None,
-    parser: argparse.ArgumentParser = check_utils.get_file_parser(),
+    parser: Optional[argparse.ArgumentParser] = None,
 ) -> int:
+    if not parser:
+        parser = check_utils.get_file_parser()
 
     parser.description = textwrap.dedent(
         """

--- a/applications_superstaq/check/pylint_.py
+++ b/applications_superstaq/check/pylint_.py
@@ -25,12 +25,14 @@ def run(
         Runs pylint on the repository (formatting check).
         """
     )
-    parser.parse_args(args)
 
-    if files is None:
+    parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
+    files = parsed_args.files
+
+    if not files:
         files = check_utils.get_tracked_files(*default_files_to_check)
 
-    return subprocess.call(["pylint", *args, *files], cwd=check_utils.root_dir)
+    return subprocess.call(["pylint", *files, *args_to_pass], cwd=check_utils.root_dir)
 
 
 if __name__ == "__main__":

--- a/applications_superstaq/check/pylint_.py
+++ b/applications_superstaq/check/pylint_.py
@@ -12,7 +12,6 @@ default_files_to_check = ("*.py",)
 
 
 @check_utils.enable_exit_on_failure
-@check_utils.extract_file_args
 @check_utils.enable_incremental(*default_files_to_check)
 def run(
     *args: str,

--- a/applications_superstaq/check/pylint_.py
+++ b/applications_superstaq/check/pylint_.py
@@ -4,7 +4,7 @@ import argparse
 import subprocess
 import sys
 import textwrap
-from typing import Iterable, Optional
+from typing import Optional
 
 from applications_superstaq.check import check_utils
 
@@ -15,7 +15,6 @@ default_files_to_check = ("*.py",)
 @check_utils.enable_incremental(*default_files_to_check)
 def run(
     *args: str,
-    files: Optional[Iterable[str]] = None,
     parser: Optional[argparse.ArgumentParser] = None,
 ) -> int:
     if not parser:
@@ -24,14 +23,19 @@ def run(
     parser.description = textwrap.dedent(
         """
         Runs pylint on the repository (formatting check).
+        NOTE: Only checks incrementally changed files by default.
         """
     )
 
+    parser.add_argument("-a", "--all", action="store_true", help="Run pylint on the entire repo.")
     parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
     files = parsed_args.files
 
+    if parsed_args.all:
+        files += check_utils.get_tracked_files(*default_files_to_check)
+
     if not files:
-        files = check_utils.get_tracked_files(*default_files_to_check)
+        files = check_utils.get_changed_files(*default_files_to_check)
 
     return subprocess.call(["pylint", *files, *args_to_pass], cwd=check_utils.root_dir)
 

--- a/applications_superstaq/check/pytest_.py
+++ b/applications_superstaq/check/pytest_.py
@@ -72,9 +72,7 @@ def run(
 
     if files is None:
         tracked_files = check_utils.get_tracked_files(*default_files_to_check, exclude=exclude)
-        files = check_utils.get_test_files(
-            *tracked_files, exclude=exclude, silent=suppress_warnings
-        )
+        files = check_utils.get_test_files(*tracked_files, exclude=exclude, silent=True)
 
     return subprocess.call(["pytest", *args, *files], cwd=check_utils.root_dir)
 

--- a/applications_superstaq/check/pytest_.py
+++ b/applications_superstaq/check/pytest_.py
@@ -18,10 +18,10 @@ default_exclude = ("*_integration_test.py",)
 def run(
     *args: str,
     files: Optional[Iterable[str]] = None,
-    parser: argparse.ArgumentParser = check_utils.get_file_parser(),
     exclude: Optional[Union[str, Iterable[str]]] = default_exclude,
     integration_exclude: Optional[Union[str, Iterable[str]]] = "dev_tools/*",
     integration_setup: Optional[Callable] = None,
+    parser: argparse.ArgumentParser = check_utils.get_file_parser(),
 ) -> int:
 
     parser.description = textwrap.dedent(

--- a/applications_superstaq/check/pytest_.py
+++ b/applications_superstaq/check/pytest_.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import argparse
 import subprocess
 import sys
 import textwrap
@@ -8,22 +7,21 @@ from typing import Callable, Iterable, Optional, Union
 
 from applications_superstaq.check import check_utils
 
-default_files_to_check = ("*.py",)
-default_exclude = ("*_integration_test.py",)
-
 
 @check_utils.enable_exit_on_failure
-@check_utils.enable_incremental(*default_files_to_check, exclude=default_exclude)
 def run(
     *args: str,
-    exclude: Optional[Union[str, Iterable[str]]] = default_exclude,
-    integration_exclude: Optional[Union[str, Iterable[str]]] = "dev_tools/*",
+    include: Union[str, Iterable[str]] = "*.py",
+    exclude: Union[str, Iterable[str]] = "*_integration_test.py",
+    notebook_include: Union[str, Iterable[str]] = "*.ipynb",
+    notebook_exclude: Union[str, Iterable[str]] = "",
+    integration_include: Union[str, Iterable[str]] = "*_integration_test.py",
+    integration_exclude: Union[str, Iterable[str]] = "dev_tools/*",
     integration_setup: Optional[Callable] = None,
-    parser: Optional[argparse.ArgumentParser] = None,
+    silent: bool = False,
 ) -> int:
-    if not parser:
-        parser = check_utils.get_file_parser()
 
+    parser = check_utils.get_file_parser()
     parser.description = textwrap.dedent(
         """
         Runs pytest on the repository.
@@ -52,27 +50,22 @@ def run(
     )
 
     parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
-    files = parsed_args.files
 
     if parsed_args.notebook:
-        args_to_pass += ("--nbmake",)
-        files = check_utils.get_tracked_files("**/*.ipynb", exclude=exclude)
+        args_to_pass += ["--nbmake"]
+        include = notebook_include
+        exclude = notebook_exclude
 
-    if parsed_args.integration:
+    elif parsed_args.integration:
         if integration_setup:
             integration_setup()
+        include = integration_include
+        exclude = integration_exclude
 
-        if not files:
-            files = check_utils.get_tracked_files(
-                "*_integration_test.py", exclude=integration_exclude
-            )
+    files = check_utils.get_file_args(parsed_args, include, exclude, silent)
 
-    elif not parsed_args.enable_socket:
-        args_to_pass += ("--disable-socket",)
-
-    if not files:
-        tracked_files = check_utils.get_tracked_files(*default_files_to_check, exclude=exclude)
-        files = check_utils.get_test_files(*tracked_files, exclude=exclude, silent=True)
+    if not parsed_args.integration and not parsed_args.enable_socket:
+        args_to_pass += ["--disable-socket"]
 
     return subprocess.call(["pytest", *files, *args_to_pass], cwd=check_utils.root_dir)
 

--- a/applications_superstaq/check/pytest_.py
+++ b/applications_superstaq/check/pytest_.py
@@ -13,11 +13,9 @@ default_exclude = ("*_integration_test.py",)
 
 
 @check_utils.enable_exit_on_failure
-@check_utils.extract_file_args
 @check_utils.enable_incremental(*default_files_to_check, exclude=default_exclude)
 def run(
     *args: str,
-    files: Optional[Iterable[str]] = None,
     exclude: Optional[Union[str, Iterable[str]]] = default_exclude,
     integration_exclude: Optional[Union[str, Iterable[str]]] = "dev_tools/*",
     integration_setup: Optional[Callable] = None,
@@ -51,30 +49,30 @@ def run(
         + "Enabled automatically if running in integration mode.",
     )
 
-    parsed_args, unknown_args = parser.parse_known_intermixed_args(args)
-    args = tuple(unknown_args)
+    parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
+    files = parsed_args.files
 
     if parsed_args.notebook:
-        args += ("--nbmake",)
+        args_to_pass += ("--nbmake",)
         files = check_utils.get_tracked_files("**/*.ipynb", exclude=exclude)
 
     if parsed_args.integration:
         if integration_setup:
             integration_setup()
 
-        if files is None:
+        if not files:
             files = check_utils.get_tracked_files(
                 "*_integration_test.py", exclude=integration_exclude
             )
 
     elif not parsed_args.enable_socket:
-        args += ("--disable-socket",)
+        args_to_pass += ("--disable-socket",)
 
-    if files is None:
+    if not files:
         tracked_files = check_utils.get_tracked_files(*default_files_to_check, exclude=exclude)
         files = check_utils.get_test_files(*tracked_files, exclude=exclude, silent=True)
 
-    return subprocess.call(["pytest", *args, *files], cwd=check_utils.root_dir)
+    return subprocess.call(["pytest", *files, *args_to_pass], cwd=check_utils.root_dir)
 
 
 if __name__ == "__main__":

--- a/applications_superstaq/check/pytest_.py
+++ b/applications_superstaq/check/pytest_.py
@@ -72,22 +72,21 @@ def _get_file_search_options(
     """If either of the include/exclude options are None, set them to reasonable defaults."""
 
     if notebook_mode:
-        if include is None:
-            include = "*.ipynb"
-        if exclude is None:
-            exclude = ""
+        default_include = "*.ipynb"
+        default_exclude = ""
 
     elif integration_mode:
-        if include is None:
-            include = "*_integration_test.py"
-        if exclude is None:
-            exclude = "dev_tools/*"
+        default_include = "*_integration_test.py"
+        default_exclude = "dev_tools/*"
 
     else:
-        if include is None:
-            include = "*_test.py"
-        if exclude is None:
-            exclude = "*_integration_test.py"
+        default_include = "*_test.py"
+        default_exclude = "*_integration_test.py"
+
+    if not include:
+        include = default_include
+    if not exclude:
+        exclude = default_exclude
 
     return include, exclude
 

--- a/applications_superstaq/check/pytest_.py
+++ b/applications_superstaq/check/pytest_.py
@@ -22,6 +22,7 @@ def run(
         """
         Runs pytest on the repository.
         By default, checks only *_test.py files, ignoring *_integration_test.py files.
+        Also passes --disable-socket to pytest, unless running with --integration or --enable-socket.
         """
     )
 
@@ -38,12 +39,7 @@ def run(
         help="Run pytest on *_integration_test.py files, ignoring dev_tools/*.",
     )
 
-    parser.add_argument(
-        "--enable-socket",
-        action="store_true",
-        help="Force-enable socket (i.e. do not pass --disable-socket to pytest). "
-        + "Enabled automatically if running in integration mode.",
-    )
+    parser.add_argument("--enable-socket", action="store_true", help="Force-enable socket.")
 
     parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
     include, exclude = _get_file_search_options(

--- a/applications_superstaq/check/pytest_.py
+++ b/applications_superstaq/check/pytest_.py
@@ -83,9 +83,9 @@ def _get_file_search_options(
         default_include = "*_test.py"
         default_exclude = "*_integration_test.py"
 
-    if not include:
+    if include is None:
         include = default_include
-    if not exclude:
+    if exclude is None:
         exclude = default_exclude
 
     return include, exclude

--- a/applications_superstaq/check/pytest_.py
+++ b/applications_superstaq/check/pytest_.py
@@ -21,7 +21,7 @@ def run(
     parser.description = textwrap.dedent(
         """
         Runs pytest on the repository.
-        Ignores integration tests unless running in integration mode.
+        By default, checks only *_test.py files, ignoring *_integration_test.py files.
         """
     )
 
@@ -30,12 +30,12 @@ def run(
     exclusive_group.add_argument(
         "--notebook",
         action="store_true",
-        help="Run pytest on all *.ipynb files in the repository.",
+        help="Run pytest on *.ipynb files.",
     )
     exclusive_group.add_argument(
         "--integration",
         action="store_true",
-        help="Run pytest on all *integration_test.py files in the repository.",
+        help="Run pytest on *_integration_test.py files, ignoring dev_tools/*.",
     )
 
     parser.add_argument(

--- a/applications_superstaq/check/pytest_.py
+++ b/applications_superstaq/check/pytest_.py
@@ -62,11 +62,10 @@ def run(
         if integration_setup:
             integration_setup()
 
-        files_to_add = check_utils.get_tracked_files(
-            "*_integration_test.py",
-            exclude=integration_exclude,
-        )
-        files = list(files) + files_to_add if files else files_to_add
+        if files is None:
+            files = check_utils.get_tracked_files(
+                "*_integration_test.py", exclude=integration_exclude
+            )
 
     elif not parsed_args.enable_socket:
         args += ("--disable-socket",)

--- a/applications_superstaq/check/pytest_.py
+++ b/applications_superstaq/check/pytest_.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import argparse
 import subprocess
 import sys
 import textwrap
@@ -47,7 +46,9 @@ def run(
     )
 
     parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
-    include, exclude = _get_file_search_options(parsed_args, include, exclude)
+    include, exclude = _get_file_search_options(
+        parsed_args.notebook, parsed_args.integration, include, exclude
+    )
     files = check_utils.get_file_args(parsed_args, include, exclude, silent)
 
     if parsed_args.notebook:
@@ -63,19 +64,20 @@ def run(
 
 
 def _get_file_search_options(
-    parsed_args: argparse.Namespace,
+    notebook_mode: bool,
+    integration_mode: bool,
     include: Optional[Union[str, Iterable[str]]],
     exclude: Optional[Union[str, Iterable[str]]],
 ) -> Tuple[Union[str, Iterable[str]], Union[str, Iterable[str]]]:
     """If either of the include/exclude options are None, set them to reasonable defaults."""
 
-    if parsed_args.notebook:
+    if notebook_mode:
         if include is None:
             include = "*.ipynb"
         if exclude is None:
             exclude = ""
 
-    elif parsed_args.integration:
+    elif integration_mode:
         if include is None:
             include = "*_integration_test.py"
         if exclude is None:

--- a/applications_superstaq/check/pytest_.py
+++ b/applications_superstaq/check/pytest_.py
@@ -19,8 +19,10 @@ def run(
     exclude: Optional[Union[str, Iterable[str]]] = default_exclude,
     integration_exclude: Optional[Union[str, Iterable[str]]] = "dev_tools/*",
     integration_setup: Optional[Callable] = None,
-    parser: argparse.ArgumentParser = check_utils.get_file_parser(),
+    parser: Optional[argparse.ArgumentParser] = None,
 ) -> int:
+    if not parser:
+        parser = check_utils.get_file_parser()
 
     parser.description = textwrap.dedent(
         """

--- a/applications_superstaq/check/pytest_.py
+++ b/applications_superstaq/check/pytest_.py
@@ -45,7 +45,7 @@ def run(
     include, exclude = _get_file_search_options(
         parsed_args.notebook, parsed_args.integration, include, exclude
     )
-    files = check_utils.get_file_args(parsed_args, include, exclude, silent)
+    files = check_utils.extract_files(parsed_args, include, exclude, silent)
 
     if parsed_args.notebook:
         args_to_pass += ["--nbmake"]

--- a/applications_superstaq/check/pytest_.py
+++ b/applications_superstaq/check/pytest_.py
@@ -22,7 +22,7 @@ def run(
         """
         Runs pytest on the repository.
         By default, checks only *_test.py files, ignoring *_integration_test.py files.
-        Also passes --disable-socket to pytest, unless running with --integration or --enable-socket.
+        Passes --disable-socket to pytest, unless running with --integration or --enable-socket.
         """
     )
 

--- a/applications_superstaq/check/pytest_.py
+++ b/applications_superstaq/check/pytest_.py
@@ -8,7 +8,7 @@ from typing import Callable, Iterable, Optional, Union
 
 from applications_superstaq.check import check_utils
 
-default_files_to_check = ("*_test.py",)
+default_files_to_check = ("*.py",)
 default_exclude = ("*_integration_test.py",)
 
 
@@ -71,7 +71,10 @@ def run(
         args += ("--disable-socket",)
 
     if files is None:
-        files = check_utils.get_tracked_files(*default_files_to_check, exclude=exclude)
+        tracked_files = check_utils.get_tracked_files(*default_files_to_check, exclude=exclude)
+        files = check_utils.get_test_files(
+            *tracked_files, exclude=exclude, silent=suppress_warnings
+        )
 
     return subprocess.call(["pytest", *args, *files], cwd=check_utils.root_dir)
 

--- a/applications_superstaq/check/pytest_.py
+++ b/applications_superstaq/check/pytest_.py
@@ -11,7 +11,7 @@ from applications_superstaq.check import check_utils
 @check_utils.enable_exit_on_failure
 def run(
     *args: str,
-    include: Union[str, Iterable[str]] = "*.py",
+    include: Union[str, Iterable[str]] = "*_test.py",
     exclude: Union[str, Iterable[str]] = "*_integration_test.py",
     notebook_include: Union[str, Iterable[str]] = "*.ipynb",
     notebook_exclude: Union[str, Iterable[str]] = "",

--- a/applications_superstaq/check/requirements.py
+++ b/applications_superstaq/check/requirements.py
@@ -24,8 +24,10 @@ def run(
     exclude: Optional[Union[str, Iterable[str]]] = None,
     silent: bool = False,
     upstream_match: str = "*superstaq",
-    parser: argparse.ArgumentParser = check_utils.get_file_parser(),
+    parser: Optional[argparse.ArgumentParser] = None,
 ) -> int:
+    if not parser:
+        parser = check_utils.get_file_parser()
 
     parser.description = textwrap.dedent(
         """

--- a/applications_superstaq/check/requirements.py
+++ b/applications_superstaq/check/requirements.py
@@ -19,13 +19,10 @@ from applications_superstaq.check import check_utils
 
 
 @check_utils.enable_exit_on_failure
-@check_utils.extract_file_args
 def run(
     *args: str,
-    files: Optional[Iterable[str]] = None,
     exclude: Optional[Union[str, Iterable[str]]] = None,
     silent: bool = False,
-    only_sort: bool = False,
     upstream_match: str = "*superstaq",
     parser: argparse.ArgumentParser = check_utils.get_file_parser(),
 ) -> int:
@@ -51,9 +48,9 @@ def run(
         help="Only sort requirements files.  Do not check upstream package versions.",
     )
     parsed_args = parser.parse_args(args)
-    only_sort |= parsed_args.only_sort
+    files = parsed_args.files
 
-    if files is None:
+    if not files:
         req_file_match = os.path.join(check_utils.root_dir, "**", "*requirements.txt")
         files = [
             os.path.relpath(file, check_utils.root_dir)
@@ -83,7 +80,7 @@ def run(
         if not is_tidy and not silent:
             print(check_utils.failure(f"{req_file} is not sorted."))
 
-        if not only_sort and can_connect_to_pypi:
+        if not parsed_args.only_sort and can_connect_to_pypi:
             is_tidy &= _pin_upstream_packages(requirements, upstream_match, silent)
 
         if not is_tidy:

--- a/applications_superstaq/check/requirements.py
+++ b/applications_superstaq/check/requirements.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import fnmatch
 import functools
 import glob
 import json
@@ -24,7 +25,7 @@ def run(
     files: Optional[Iterable[str]] = None,
     parser: argparse.ArgumentParser = check_utils.get_file_parser(add_files=False),
     exclude: Optional[Union[str, Iterable[str]]] = None,
-    upstream_match: str = ".*superstaq",
+    upstream_match: str = "*superstaq",
     silent: bool = False,
     only_sort: bool = False,
 ) -> int:
@@ -149,7 +150,7 @@ def _pin_upstream_packages(requirements: List[str], upstream_match: str, silent:
     upstream_versions = {
         package: _get_latest_version(package)
         for requirement in requirements
-        if re.match(upstream_match, package := re.split(">|<|~|=", requirement)[0])
+        if fnmatch.fnmatch(package := re.split(">|<|~|=", requirement)[0], upstream_match)
     }
 
     # pin upstream packages to their latest versions

--- a/applications_superstaq/check/requirements.py
+++ b/applications_superstaq/check/requirements.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 
-import argparse
 import fnmatch
 import functools
-import glob
 import json
 import os
 import re
@@ -11,7 +9,7 @@ import subprocess
 import sys
 import textwrap
 import urllib.request
-from typing import Dict, Iterable, List, Optional, Tuple, Union
+from typing import Dict, Iterable, List, Tuple, Union
 
 import pkg_resources
 
@@ -21,14 +19,13 @@ from applications_superstaq.check import check_utils
 @check_utils.enable_exit_on_failure
 def run(
     *args: str,
-    exclude: Optional[Union[str, Iterable[str]]] = None,
-    silent: bool = False,
+    include: Union[str, Iterable[str]] = "*requirements.txt",
+    exclude: Union[str, Iterable[str]] = "",
     upstream_match: str = "*superstaq",
-    parser: Optional[argparse.ArgumentParser] = None,
+    silent: bool = False,
 ) -> int:
-    if not parser:
-        parser = check_utils.get_file_parser()
 
+    parser = check_utils.get_file_parser()
     parser.description = textwrap.dedent(
         """
         Checks that:
@@ -50,15 +47,7 @@ def run(
         help="Only sort requirements files.  Do not check upstream package versions.",
     )
     parsed_args = parser.parse_intermixed_args(args)
-    files = parsed_args.files
-
-    if not files:
-        req_file_match = os.path.join(check_utils.root_dir, "**", "*requirements.txt")
-        files = [
-            os.path.relpath(file, check_utils.root_dir)
-            for file in glob.iglob(req_file_match, recursive=True)
-        ]
-    files = filter(check_utils.inclusion_filter(exclude), files)
+    files = check_utils.get_file_args(parsed_args, include, exclude, silent)
 
     # check that we can connect to PyPI
     can_connect_to_pypi = _check_pypy_connection(silent)

--- a/applications_superstaq/check/requirements.py
+++ b/applications_superstaq/check/requirements.py
@@ -47,7 +47,7 @@ def run(
         help="Only sort requirements files.  Do not check upstream package versions.",
     )
     parsed_args = parser.parse_intermixed_args(args)
-    files = check_utils.get_file_args(parsed_args, include, exclude, silent)
+    files = check_utils.extract_files(parsed_args, include, exclude, silent)
 
     # check that we can connect to PyPI
     can_connect_to_pypi = _check_pypy_connection(silent)

--- a/applications_superstaq/check/requirements.py
+++ b/applications_superstaq/check/requirements.py
@@ -23,11 +23,11 @@ from applications_superstaq.check import check_utils
 def run(
     *args: str,
     files: Optional[Iterable[str]] = None,
-    parser: argparse.ArgumentParser = check_utils.get_file_parser(add_files=False),
     exclude: Optional[Union[str, Iterable[str]]] = None,
-    upstream_match: str = "*superstaq",
     silent: bool = False,
     only_sort: bool = False,
+    upstream_match: str = "*superstaq",
+    parser: argparse.ArgumentParser = check_utils.get_file_parser(),
 ) -> int:
 
     parser.description = textwrap.dedent(

--- a/applications_superstaq/check/requirements.py
+++ b/applications_superstaq/check/requirements.py
@@ -47,7 +47,7 @@ def run(
         action="store_true",
         help="Only sort requirements files.  Do not check upstream package versions.",
     )
-    parsed_args = parser.parse_args(args)
+    parsed_args = parser.parse_intermixed_args(args)
     files = parsed_args.files
 
     if not files:


### PR DESCRIPTION
fixes #80 and #84 
also:
- make `check.requirements.run` use bash-style (as opposed to re-style) regexp for the `upstream_match` argument
- remove `examples/*.py` from the default excludes for `check/coverage_.py` (see #66)
- simplify how `check` scripts parse file/directory arguments (see discussions in the comments below)
- make `check/pylint_.py` incremental by default (with `-a/--all` options to check everything in the repo)